### PR TITLE
Remove unused checkDelay setting

### DIFF
--- a/background.js
+++ b/background.js
@@ -292,7 +292,6 @@ class BackgroundService {
       enabled: true,
       apiKey: '',
       minLength: 10,
-      checkDelay: 1000,
       todayChecks: 0,
       totalChecks: 0,
       totalIssues: 0,
@@ -324,7 +323,7 @@ class BackgroundService {
           break;
 
         case 'GET_SETTINGS':
-          const settings = await this.getStorageData(['enabled', 'apiKey', 'minLength', 'checkDelay']);
+          const settings = await this.getStorageData(['enabled', 'apiKey', 'minLength']);
           sendResponse({ success: true, data: settings });
           break;
 
@@ -396,7 +395,7 @@ class BackgroundService {
   async handleStorageChange(changes, namespace) {
     if (namespace === 'sync') {
       // 設定変更をコンテンツスクリプトに通知
-      if (changes.enabled || changes.apiKey || changes.minLength || changes.checkDelay) {
+      if (changes.enabled || changes.apiKey || changes.minLength) {
         this.notifyAllTabs('SETTINGS_CHANGED', changes);
         
         // 有効/無効設定が変更された場合はコンテキストメニューを更新

--- a/popup.html
+++ b/popup.html
@@ -216,11 +216,6 @@
     <div class="setting-description">この文字数以上でAIチェックを開始</div>
   </div>
 
-  <div class="setting-group">
-    <label class="setting-label" for="checkDelay">チェック遅延時間（ミリ秒）</label>
-    <input type="number" id="checkDelay" class="setting-input" min="500" max="5000" step="500" value="1000">
-    <div class="setting-description">入力停止後にチェックを開始するまでの時間</div>
-  </div>
 
   <button class="save-button" id="saveButton">設定を保存</button>
   

--- a/popup.js
+++ b/popup.js
@@ -17,7 +17,6 @@ class SettingsManager {
       enabledToggle: document.getElementById('enabledToggle'),
       apiKey: document.getElementById('apiKey'),
       minLength: document.getElementById('minLength'),
-      checkDelay: document.getElementById('checkDelay'),
       saveButton: document.getElementById('saveButton'),
       statusMessage: document.getElementById('statusMessage'),
       todayChecks: document.getElementById('todayChecks'),
@@ -45,7 +44,7 @@ class SettingsManager {
     });
 
     // 入力フィールドの変更を監視
-    [this.elements.apiKey, this.elements.minLength, this.elements.checkDelay].forEach(input => {
+    [this.elements.apiKey, this.elements.minLength].forEach(input => {
       input.addEventListener('input', () => {
         this.hideStatusMessage();
       });
@@ -63,14 +62,13 @@ class SettingsManager {
 
   async loadSettings() {
     try {
-      const settings = await this.getStorageData(['enabled', 'apiKey', 'minLength', 'checkDelay']);
+      const settings = await this.getStorageData(['enabled', 'apiKey', 'minLength']);
       
       // デフォルト値の設定
       const defaults = {
         enabled: true,
         apiKey: '',
-        minLength: 20,
-        checkDelay: 1000
+        minLength: 20
       };
 
       // UIに反映
@@ -81,7 +79,6 @@ class SettingsManager {
 
       this.elements.apiKey.value = settings.apiKey || defaults.apiKey;
       this.elements.minLength.value = settings.minLength || defaults.minLength;
-      this.elements.checkDelay.value = settings.checkDelay || defaults.checkDelay;
 
     } catch (error) {
       console.error('設定の読み込みエラー:', error);
@@ -119,8 +116,7 @@ class SettingsManager {
       const settings = {
         enabled: this.elements.enabledToggle.classList.contains('active'),
         apiKey: this.elements.apiKey.value.trim(),
-        minLength: parseInt(this.elements.minLength.value),
-        checkDelay: parseInt(this.elements.checkDelay.value)
+        minLength: parseInt(this.elements.minLength.value)
       };
 
       // バリデーション
@@ -161,9 +157,6 @@ class SettingsManager {
       return { isValid: false, message: '最小チェック文字数は10-1000の範囲で設定してください' };
     }
 
-    if (settings.checkDelay < 500 || settings.checkDelay > 5000) {
-      return { isValid: false, message: 'チェック遅延時間は500-5000ミリ秒の範囲で設定してください' };
-    }
 
     if (settings.enabled && !settings.apiKey) {
       return { isValid: false, message: '機能を有効にするにはAPIキーが必要です' };


### PR DESCRIPTION
## Summary
- delete checkDelay option from settings UI
- remove checkDelay handling logic in popup script
- strip checkDelay from background defaults and storage logic

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_683f95c7967483288f10456ff5fdad9f